### PR TITLE
ホームとウォレット詳細ページ実装

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
 import { IconAccount } from '@/components/atom/Icons';
+import { useI18n } from '@/hooks/useI18n';
 import { useLoadedAssets } from '@/hooks/useLoadedAssets';
 import { PermissionError } from '@/models/ErrorModels';
 import { DeviceHealthService } from '@/services/DeviceHealthService';
@@ -18,8 +19,20 @@ export { ErrorBoundary } from 'expo-router';
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout(): JSX.Element {
+  return (
+    <I18nProvider>
+      <StateProvider>
+        <RootLayoutContent />
+        <Toast />
+      </StateProvider>
+    </I18nProvider>
+  );
+}
+
+function RootLayoutContent(): JSX.Element {
   const pathname = usePathname();
   const isLoadingComplete = useLoadedAssets();
+  const { t } = useI18n();
 
   useEffect(() => {
     console.debug(`root: current page is ${pathname}`);
@@ -51,43 +64,45 @@ export default function RootLayout(): JSX.Element {
   }
 
   return (
-    <I18nProvider>
-      <StateProvider>
-        <Stack initialRouteName='index'>
-          {/* Root Route */}
-          <Stack.Screen name='admin' options={{ headerShown: true }} />
-          <Stack.Screen
-            name='index'
-            options={{
-              title: modeConfig.APPLICATION_NAME,
-              headerShown: true,
-              headerBackVisible: false,
-              headerRight: handleHeaderRightClickForPage,
-            }}
-          />
-          {/* Root - Modal Group */}
-          <Stack.Screen name='(modals)/modal_camera' options={{ headerShown: true }} />
-          <Stack.Screen name='(modals)/modal_create_transaction' options={{ headerShown: true }} />
-          {/* Root - Account Group */}
-          <Stack.Screen name='(account)/account_contract' options={{ headerShown: true }} />
-          <Stack.Screen name='(account)/account_create' options={{ headerShown: false }} />
-          {/* Root - Network Group */}
-          <Stack.Screen name='(network)/network_index' options={{ headerShown: false }} />
-          <Stack.Screen name='(network)/network_node_custom' options={{ headerShown: false }} />
-          <Stack.Screen name='(network)/network_node_select' options={{ headerShown: false }} />
-          <Stack.Screen name='(network)/network_type_select' options={{ headerShown: false }} />
-          {/* Root - System Group */}
-          <Stack.Screen name='(system)/system_license' options={{ headerShown: false }} />
-          <Stack.Screen name='(system)/system_policy' options={{ headerShown: false }} />
-          <Stack.Screen name='(system)/system_qa' options={{ headerShown: false }} />
-          <Stack.Screen name='(system)/system_terms' options={{ headerShown: false }} />
-          {/* Wallet Route */}
-          <Stack.Screen name='wallet/[public_key]' options={{ headerShown: true }} />
-          {/* Login Route */}
-          <Stack.Screen name='login' options={{ headerShown: false }} />
-        </Stack>
-      </StateProvider>
-      <Toast />
-    </I18nProvider>
+    <Stack initialRouteName='index'>
+      {/* Root Route */}
+      <Stack.Screen name='admin' options={{ headerShown: true }} />
+      <Stack.Screen
+        name='index'
+        options={{
+          title: modeConfig.APPLICATION_NAME,
+          headerShown: true,
+          headerBackVisible: false,
+          headerRight: handleHeaderRightClickForPage,
+        }}
+      />
+      {/* Root - Modal Group */}
+      <Stack.Screen name='(modals)/modal_camera' options={{ headerShown: true }} />
+      <Stack.Screen name='(modals)/modal_create_transaction' options={{ headerShown: true }} />
+      {/* Root - Account Group */}
+      <Stack.Screen name='(account)/account_contract' options={{ headerShown: true }} />
+      <Stack.Screen name='(account)/account_create' options={{ headerShown: false }} />
+      {/* Root - Network Group */}
+      <Stack.Screen name='(network)/network_index' options={{ headerShown: false }} />
+      <Stack.Screen name='(network)/network_node_custom' options={{ headerShown: false }} />
+      <Stack.Screen name='(network)/network_node_select' options={{ headerShown: false }} />
+      <Stack.Screen name='(network)/network_type_select' options={{ headerShown: false }} />
+      {/* Root - System Group */}
+      <Stack.Screen name='(system)/system_license' options={{ headerShown: false }} />
+      <Stack.Screen name='(system)/system_policy' options={{ headerShown: false }} />
+      <Stack.Screen name='(system)/system_qa' options={{ headerShown: false }} />
+      <Stack.Screen name='(system)/system_terms' options={{ headerShown: false }} />
+      {/* Wallet Route */}
+      <Stack.Screen
+        name='wallet/[public_key]'
+        options={{
+          headerShown: true,
+          title: t('pages.layout.wallet.title'),
+          headerBackTitle: t('pages.layout.wallet.header_back_title'),
+        }}
+      />
+      {/* Login Route */}
+      <Stack.Screen name='login' options={{ headerShown: false }} />
+    </Stack>
   );
 }

--- a/app/admin.tsx
+++ b/app/admin.tsx
@@ -17,6 +17,7 @@ import Switch from '@/components/atom/Switch';
 import Tabs from '@/components/atom/Tabs';
 import TextArea from '@/components/atom/Textarea';
 import { AccountController } from '@/controller/AccountController';
+import { NotificationService } from '@/services/NotificationService';
 import { STORAGE_KEYS } from '@/util/configs/storage-keys';
 import { AsyncStorage } from '@/util/storages/AsyncStorage';
 import { SecureStorage } from '@/util/storages/SecureStorage';
@@ -47,12 +48,17 @@ export default function Root(): React.JSX.Element {
     loadAsyncStorageData();
   }, []);
 
+  const testPushNotification = async () => {
+    await new NotificationService().sendPushNotification('test', 'hello world', { key: 'test' });
+  };
+
   return (
     <View className='flex-1'>
       <ScrollView>
         <View className='flex justify-start items-stretch gap-y-10 p-2 bg-background'>
           <Text className='font-bold'>このスクリーンは開発中に Atom Component 等を確認するための検証用です。</Text>
           <View className='flex flex-col space-y-4'>
+            <Button onPress={testPushNotification}>tset</Button>
             <Button onPress={() => AccountController.createNewPrivateKeyAccount('testnet')}>WALLET 設定追加</Button>
             <Button>WALLET 設定追加</Button>
             <Button onPress={() => new SecureStorage(STORAGE_KEYS.secure.ACCOUNT).resetSecretItem()}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,21 +1,50 @@
 import { Link, useNavigation, useRouter } from 'expo-router';
 import * as React from 'react';
 import { View, Text } from 'react-native';
+import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
-import Button from '@/components/atom/Button';
 import ButtonBase from '@/components/atom/ButtonBase';
 import { List } from '@/components/atom/List';
+import { useGetCurrentBalance } from '@/hooks/useGetCurrentBalance';
+import { useLoadCurrentNetwork } from '@/hooks/useLoadCurrentNetwork';
 import { useLoadWallets } from '@/hooks/useLoadWallets';
 import { WalletModel } from '@/models/AccountModel';
 import { AddressService } from '@/services/AddressService';
-import { NotificationService } from '@/services/NotificationService';
 
-function Item({ item }: { item: WalletModel }) {
+function useHooks() {
+  const loadWallets = useLoadWallets();
+  const loadNetworks = useLoadCurrentNetwork();
+
+  return {
+    isLoading: loadWallets.isLoading || loadNetworks.isLoading,
+    error: loadWallets.error || loadNetworks.error,
+    wallets: loadWallets.wallets.filter((e) => e.networkType === loadNetworks.network?.network.networkType),
+    connection: loadNetworks.network?.connection,
+    restGateway: loadNetworks.network?.network.restGatewayUrl,
+    networkType: loadNetworks.network?.network.networkType,
+  };
+}
+
+function Item({
+  item,
+  node,
+  onRefresh,
+}: {
+  item: WalletModel;
+  node?: string;
+  onRefresh: (refresh: () => Promise<void>) => void;
+}) {
   const router = useRouter();
-
+  const { isLoading, error, balance, refresh } = useGetCurrentBalance(
+    AddressService.createFromPublicKey(item.publicKey, item.networkType).plain(),
+    node || ''
+  );
   const onPressItem = () => {
     router.push(`/wallet/${item.publicKey}`);
   };
+  React.useEffect(() => {
+    onRefresh(refresh);
+  }, [refresh]);
 
   return (
     <ButtonBase onPress={onPressItem} className='w-screen'>
@@ -25,8 +54,8 @@ function Item({ item }: { item: WalletModel }) {
         <Text className='text-base'>
           {AddressService.createFromPublicKey(item.publicKey, item.networkType).pretty()}
         </Text>
-        {/* TODO: 暫定で固定値挿入 */}
-        <Text className='text-2xl text-right'>{(100000).toLocaleString('ja') + ' xym'}</Text>
+        {!isLoading && <Text className='text-2xl text-right'>{balance.toLocaleString('ja') + ' xym'}</Text>}
+        {error && <Text className='text-red-500 text-right'>{error.message}</Text>}
       </View>
     </ButtonBase>
   );
@@ -38,8 +67,9 @@ export type TempType = {
 export default function Root(): React.JSX.Element {
   const navigation = useNavigation();
   const router = useRouter();
-  const { isLoading, wallets } = useLoadWallets();
   const [isWalletsInfoReload, setIsWalletsInfoReload] = React.useState<boolean>(false);
+  const { isLoading, wallets, connection, restGateway } = useHooks();
+  const refreshFunctions = React.useRef<(() => Promise<void>)[]>([]);
 
   React.useEffect(() => {
     const state = navigation.getState();
@@ -57,19 +87,24 @@ export default function Root(): React.JSX.Element {
     }
   }, [isLoading, wallets]);
 
-  const testPushNotification = async () => {
-    await new NotificationService().sendPushNotification('test', 'hello world', { key: 'test' });
-  };
-
-  const reloadAccountInfo = () => {
+  const reloadAccountInfo = async () => {
+    if (connection === 'disconnected') {
+      Toast.show({ type: 'error', text1: 'Node disconnected' });
+      return;
+    }
     setIsWalletsInfoReload(true);
     try {
-      // TODO: 実際にはノードよりアドレスに紐づく残高情報を取得する
+      // 実際にはノードよりアドレスに紐づく残高情報を取得する
+      await Promise.all(refreshFunctions.current.map((refresh) => refresh()));
     } catch (err) {
       console.error(err);
     } finally {
       setIsWalletsInfoReload(false);
     }
+  };
+
+  const handleRefresh = (refresh: () => Promise<void>) => {
+    refreshFunctions.current.push(refresh);
   };
 
   return (
@@ -78,16 +113,15 @@ export default function Root(): React.JSX.Element {
         <Text>Loading...</Text>
       ) : (
         <>
-          <Link href='/_sitemap' className='text-blue-700 underline text-center py-10 text-lg'>
-            開発用 - サイトマップへ
-          </Link>
-          <Button onPress={testPushNotification}>tset</Button>
           <List
             items={wallets}
-            renderItem={(item) => <Item item={item} />}
+            renderItem={(item) => <Item item={item} node={restGateway} onRefresh={handleRefresh} />}
             onRefresh={reloadAccountInfo}
             refreshing={isWalletsInfoReload}
           />
+          <Link href='/_sitemap' className='text-blue-700 underline text-center py-10 text-lg'>
+            開発用 - サイトマップへ
+          </Link>
         </>
       )}
     </View>

--- a/app/wallet/[public_key]/_layout.tsx
+++ b/app/wallet/[public_key]/_layout.tsx
@@ -43,7 +43,7 @@ export default function WalletPublicKeyDynamicLayout(): JSX.Element {
         options={{
           headerShown: false,
           tabBarIcon: () => <IconWallet size={20} className='text-primary' />,
-          tabBarLabel: 'Home',
+          tabBarLabel: t('pages.wallet.layout.home_tab_name'),
         }}
       />
       <Tabs.Screen
@@ -53,15 +53,16 @@ export default function WalletPublicKeyDynamicLayout(): JSX.Element {
           headerShown: false,
           headerTitle: t('pages.wallet.layout.transactions_tab_name'),
           tabBarIcon: () => <IconReceipt size={20} className='text-primary' />,
-          tabBarLabel: 'History',
+          tabBarLabel: t('pages.wallet.layout.transactions_tab_name'),
         }}
       />
+      {/* TODO まだ表示しない */}
       <Tabs.Screen
         name='tabs_account_qr'
         initialParams={currentWallet}
         options={{
           headerShown: false,
-          headerTitle: 'QR',
+          headerTitle: t('pages.wallet.layout.qr_tab_name'),
           href: null,
         }}
       />

--- a/app/wallet/[public_key]/tabs_home.tsx
+++ b/app/wallet/[public_key]/tabs_home.tsx
@@ -1,33 +1,70 @@
 import * as Clipboard from 'expo-clipboard';
 import { useLocalSearchParams } from 'expo-router';
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, ScrollView } from 'react-native';
 import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
 import { Card, CardFooter, CardHeader } from '@/components/atom/Card';
+import FormattedAmount from '@/components/atom/FormattedAmount';
+import { useGetCurrentBalance } from '@/hooks/useGetCurrentBalance';
 import { useI18n } from '@/hooks/useI18n';
+import { useLoadCurrentNetwork } from '@/hooks/useLoadCurrentNetwork';
 import { WalletModel } from '@/models/AccountModel';
 import { AddressService } from '@/services/AddressService';
+
+function useHooks() {
+  const loadNetworks = useLoadCurrentNetwork();
+
+  return {
+    connection: loadNetworks.network?.connection,
+    restGateway: loadNetworks.network?.network.restGatewayUrl,
+    networkType: loadNetworks.network?.network.networkType,
+  };
+}
 
 export default function WalletAccountDetail(): JSX.Element {
   const { t } = useI18n();
   const params = useLocalSearchParams() as unknown as WalletModel;
-  const address = AddressService.createFromPublicKey(params.publicKey, params.networkType);
+  const { restGateway } = useHooks();
 
+  const address = AddressService.createFromPublicKey(params.publicKey, params.networkType);
+  const { isLoading, balance, mosaics } = useGetCurrentBalance(address.plain(), restGateway || null);
   const copyAddress = () => {
     Clipboard.setStringAsync(address.plain()).then(() => Toast.show({ text1: t('common.copied') }));
   };
 
   return (
-    <View className='flex-1 items-center gap-3 px-4 pt-3'>
-      <Card className='w-full p-4' color='default'>
-        <Text className='text-sm text-right text-muted-foreground'>{params.networkType}</Text>
-        <Pressable onLongPress={copyAddress}>
-          {({ pressed }) => <CardHeader className={pressed ? 'opacity-20' : undefined}>{address?.pretty()}</CardHeader>}
-        </Pressable>
-        <CardFooter>
-          <Text className='text-2xl'>{(100000000000).toLocaleString('ja')} xym</Text>
-        </CardFooter>
-      </Card>
-    </View>
+    <>
+      <View className='flex-1 items-center gap-3 pt-3'>
+        <ScrollView>
+          <Card className='w-full p-4 mb-2' color='default'>
+            <Text className='text-sm text-right text-muted-foreground'>{params.networkType}</Text>
+            <Pressable onLongPress={copyAddress}>
+              {({ pressed }) => (
+                <CardHeader className={pressed ? 'opacity-20' : undefined} style={{ minWidth: '90%' }}>
+                  {address?.pretty()}
+                </CardHeader>
+              )}
+            </Pressable>
+            <CardFooter>
+              {isLoading && <Text className='text-sm text-muted-foreground'>Loading...</Text>}
+              {!isLoading && <Text className='text-2xl'>{balance.toLocaleString('ja')} xym</Text>}
+            </CardFooter>
+          </Card>
+
+          <Text className='text-xl my-4'>{t('pages.wallet.tabsHome.owned_mosaics')}</Text>
+
+          {mosaics.map((mosaic) => {
+            return (
+              <Card className='w-full p-4' color='default' key={mosaic.id}>
+                <CardHeader>{mosaic.namespace ?? mosaic.id}</CardHeader>
+                <CardFooter>
+                  <FormattedAmount amount={mosaic.amount} className='text-2xl' />
+                </CardFooter>
+              </Card>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </>
   );
 }

--- a/app/wallet/[public_key]/tabs_home.tsx
+++ b/app/wallet/[public_key]/tabs_home.tsx
@@ -3,9 +3,10 @@ import { useLocalSearchParams } from 'expo-router';
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
+import Button from '@/components/atom/Button';
 import { Card, CardFooter, CardHeader } from '@/components/atom/Card';
 import FormattedAmount from '@/components/atom/FormattedAmount';
-import { useGetCurrentBalance } from '@/hooks/useGetCurrentBalance';
+import { useGetCurrentBalance, FETCH_MOSAICS_LIMIT } from '@/hooks/useGetCurrentBalance';
 import { useI18n } from '@/hooks/useI18n';
 import { useLoadCurrentNetwork } from '@/hooks/useLoadCurrentNetwork';
 import { WalletModel } from '@/models/AccountModel';
@@ -27,7 +28,7 @@ export default function WalletAccountDetail(): JSX.Element {
   const { restGateway } = useHooks();
 
   const address = AddressService.createFromPublicKey(params.publicKey, params.networkType);
-  const { isLoading, balance, mosaics } = useGetCurrentBalance(address.plain(), restGateway || null);
+  const { isLoading, balance, mosaics, loadMoreMosaics } = useGetCurrentBalance(address.plain(), restGateway || null);
   const copyAddress = () => {
     Clipboard.setStringAsync(address.plain()).then(() => Toast.show({ text1: t('common.copied') }));
   };
@@ -51,18 +52,30 @@ export default function WalletAccountDetail(): JSX.Element {
             </CardFooter>
           </Card>
 
-          <Text className='text-xl my-4'>{t('pages.wallet.tabsHome.owned_mosaics')}</Text>
+          {mosaics.length > 0 && (
+            <View>
+              <Text className='text-xl my-4'>{t('pages.wallet.tabsHome.owned_mosaics')}</Text>
 
-          {mosaics.map((mosaic) => {
-            return (
-              <Card className='w-full p-4' color='default' key={mosaic.id}>
-                <CardHeader>{mosaic.namespace ?? mosaic.id}</CardHeader>
-                <CardFooter>
-                  <FormattedAmount amount={mosaic.amount} className='text-2xl' />
-                </CardFooter>
-              </Card>
-            );
-          })}
+              {mosaics.map((mosaic) => {
+                return (
+                  <Card className='w-full p-4' color='default' key={mosaic.id}>
+                    <CardHeader>{mosaic.namespace ?? mosaic.id}</CardHeader>
+                    <CardFooter>
+                      <FormattedAmount amount={mosaic.amount} className='text-2xl' />
+                    </CardFooter>
+                  </Card>
+                );
+              })}
+              {mosaics.length > 0 && mosaics.length % FETCH_MOSAICS_LIMIT === 0 && (
+                <View>
+                  <Button onPress={loadMoreMosaics}>{t('pages.wallet.tabsHome.owned_mosaics_show_more')}</Button>
+                </View>
+              )}
+              <Text>
+                {FETCH_MOSAICS_LIMIT}, {mosaics.length}, {mosaics.length % FETCH_MOSAICS_LIMIT}
+              </Text>
+            </View>
+          )}
         </ScrollView>
       </View>
     </>

--- a/app/wallet/[public_key]/tabs_transactions.tsx
+++ b/app/wallet/[public_key]/tabs_transactions.tsx
@@ -1,50 +1,59 @@
-// import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
+import React from 'react';
 import { View } from 'react-native';
 
 import Tabs from '@/components/atom/Tabs';
-import ReceievedTransactionHistory from '@/components/organisms/ReceievedTransactionHistory';
+import ReceivedTransactionHistory from '@/components/organisms/ReceivedTransactionHistory';
 import SendTransactionHistory from '@/components/organisms/SendTransactionHistory';
-// import { useI18n } from '@/hooks/useI18n';
+import { useI18n } from '@/hooks/useI18n';
 import { useLoadCurrentNetwork } from '@/hooks/useLoadCurrentNetwork';
-// import { WalletModel } from '@/models/AccountModel';
-// import { AddressService } from '@/services/AddressService';
+import { WalletModel } from '@/models/AccountModel';
+import { AddressService } from '@/services/AddressService';
 
 export default function WalletAccountTransactions(): JSX.Element {
-  // const { t } = useI18n();
-  // const params = useLocalSearchParams() as unknown as WalletModel;
+  const { t } = useI18n();
+  const params = useLocalSearchParams() as unknown as WalletModel;
   const { isLoading, error, network } = useLoadCurrentNetwork();
 
   if (error) throw error;
 
   return (
     <View className='flex-1 px-3 pt-4 bg-background'>
-      <Tabs
-        defaultTab='受信'
-        tabs={[
-          // { name: '受信', content: <ReceievedTransactionHistory recipientAddress={address.plain()} /> },
-          {
-            name: '受信',
-            content: (
-              <ReceievedTransactionHistory
-                node={isLoading || !network?.network.restGatewayUrl ? null : network.network.restGatewayUrl}
-                recipientAddress='TAILJXZJA3JQZ5YN7DUAWS7M4K7RT7UX275PQRI'
-              />
-            ),
-          },
-          // { name: '送信', content: <SendTransactionHistory signerPublicKey={params.publicKey} /> },
-          {
-            name: '送信',
-            content: (
-              <SendTransactionHistory
-                node={isLoading || !network?.network.restGatewayUrl ? null : network.network.restGatewayUrl}
-                signerPublicKey='E959F11B571C3DC2EB4FA82107A4878989E528D3D82320E5C9DC890763F502E4'
-              />
-            ),
-          },
-          { name: '署名中', content: <View /> },
-          { name: '収穫', content: <View /> },
-        ]}
-      />
+      {!isLoading && (
+        <>
+          <Tabs
+            defaultTab={t('common.receive')}
+            tabs={[
+              {
+                name: t('common.receive'),
+                content: (
+                  <ReceivedTransactionHistory
+                    node={network?.network.restGatewayUrl || null}
+                    networkType={network?.network.networkType || 'mainnet'}
+                    recipientAddress={AddressService.createFromPublicKey(
+                      params.publicKey,
+                      network?.network.networkType!
+                    ).plain()}
+                  />
+                ),
+              },
+              {
+                name: t('common.send'),
+                content: (
+                  <SendTransactionHistory
+                    node={network?.network.restGatewayUrl || null}
+                    networkType={network?.network.networkType || 'mainnet'}
+                    signerPublicKey={params.publicKey}
+                  />
+                ),
+              },
+              // TODO 後日実装
+              // { name: '署名中', content: <View /> },
+              // { name: '収穫', content: <View /> },
+            ]}
+          />
+        </>
+      )}
     </View>
   );
 }

--- a/components/atom/FormattedAmount.tsx
+++ b/components/atom/FormattedAmount.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Text } from 'react-native';
+
+interface Props {
+  amount: number;
+  className?: string;
+}
+/** 整数部に3桁ごとにカンマを挿入する */
+const FormattedAmount = ({ amount, className }: Props): JSX.Element => {
+  const formatAmount = (value: number) => {
+    // 整数部と小数部に分割
+    const [integerPart, fractionalPart] = String(value).split('.');
+
+    // 整数部に3桁ごとにカンマを挿入
+    const formattedIntegerPart = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+    // 整数部と小数部を結合
+    return `${formattedIntegerPart}${fractionalPart ? `.${fractionalPart}` : ''}`;
+  };
+
+  return <Text className={className}>{formatAmount(amount)}</Text>;
+};
+
+export default FormattedAmount;

--- a/components/organisms/HarvestingTransactionHistory.tsx
+++ b/components/organisms/HarvestingTransactionHistory.tsx
@@ -5,7 +5,7 @@ import { View, Text } from 'react-native';
 import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
-import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
 import { getExplorerUrl } from '@/util/symbol/network';
 
 interface Props {

--- a/components/organisms/ReceivedTransactionHistory.tsx
+++ b/components/organisms/ReceivedTransactionHistory.tsx
@@ -7,7 +7,7 @@ import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
 import { useI18n } from '@/hooks/useI18n';
-import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
 import { NetworkType } from '@/models/NetworkModels';
 import { NETWORK_PROPERTIES } from '@/util/configs/network-properties';
 import { getExplorerUrl } from '@/util/symbol/network';

--- a/components/organisms/ReceivedTransactionHistory.tsx
+++ b/components/organisms/ReceivedTransactionHistory.tsx
@@ -1,28 +1,42 @@
 import { useRouter } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { View, Text } from 'react-native';
+import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
 import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
+import { useI18n } from '@/hooks/useI18n';
 import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { NetworkType } from '@/models/NetworkModels';
+import { NETWORK_PROPERTIES } from '@/util/configs/network-properties';
 import { getExplorerUrl } from '@/util/symbol/network';
 
 interface Props {
   node: string | null;
   recipientAddress: string;
+  networkType: NetworkType;
 }
 
-export default function ReceievedTransactionHistory(props: Props): JSX.Element {
+export default function ReceivedTransactionHistory(props: Props): JSX.Element {
   const router = useRouter();
+  const { t } = useI18n();
   const { isLoading, error, next, refresh, transactions } = useTransactionHistory(props.node, 'confirmed', {
     order: 'desc',
     recipientAddress: props.recipientAddress,
     embedded: true,
   });
 
+  const epochAdjustment = useMemo(() => {
+    return NETWORK_PROPERTIES[props.networkType || 'mainnet'].epochAdjustment;
+  }, [props.networkType]);
+
   useEffect(() => {
     if (error) {
+      Toast.show({
+        text1: error.message,
+        type: 'error',
+      });
       console.error(error);
     }
   }, [error]);
@@ -33,15 +47,17 @@ export default function ReceievedTransactionHistory(props: Props): JSX.Element {
       onRefresh={refresh}
       refreshing={isLoading}
       renderItem={(e) => (
-        // TODO: 実際には useTransactionHistory が接続中 NODE の NetworkType 等を返却するべきであるため、Network 周りの実装が完了次第、以下も更新する
         <ButtonBase
-          onPress={() => router.push(getExplorerUrl('mainnet', 'transactions', e.meta.hash || e.meta.aggregateHash))}
+          onPress={() =>
+            router.push(getExplorerUrl(props.networkType, 'transactions', e.meta.hash || e.meta.aggregateHash))
+          }
         >
           <ListItem className='flex-col items-start rounded-md border border-input'>
-            <Text className='text-base font-semibold'>{e.transaction.type}</Text>
-            {/* TODO: Network 情報を取得できるようになり次第、以下の実装を進める */}
-            <Text>{new Date(Number(e.meta.timestamp) + 1615853185 * 1000).toLocaleString('ja')}</Text>
-            <Text className='text-xs text-muted-foreground'>{e.meta.hash || e.meta.aggregateHash}</Text>
+            <Text className='text-base font-semibold'>
+              {new Date(Number(e.meta.timestamp) + epochAdjustment * 1000).toLocaleString('ja')}
+            </Text>
+            <Text>{e.meta.hash || e.meta.aggregateHash}</Text>
+            <Text className='text-xs text-muted-foreground'>{e.meta.height} block</Text>
           </ListItem>
         </ButtonBase>
       )}
@@ -50,11 +66,13 @@ export default function ReceievedTransactionHistory(props: Props): JSX.Element {
           <ButtonBase onPress={next} disabled={isLoading ?? error}>
             <View className='w-full flex flex-row gap-2 justify-center items-center py-12'>
               <IconDown isOutline={false} className='text-muted-foreground' />
-              <Text className='text-base text-muted-foreground'>Load More...</Text>
+              <Text className='text-base text-muted-foreground'>{t('common.loadMore')}</Text>
             </View>
           </ButtonBase>
         ) : (
-          <Text className='text-lg text-muted-foreground py-32 text-center'>No transaction history</Text>
+          <Text className='text-lg text-muted-foreground py-32 text-center'>
+            {t('organisms.ReceivedTransactionHistory.noTransactionHistory')}
+          </Text>
         )
       }
     />

--- a/components/organisms/SendTransactionHistory.tsx
+++ b/components/organisms/SendTransactionHistory.tsx
@@ -1,28 +1,42 @@
 import { useRouter } from 'expo-router';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { View, Text } from 'react-native';
+import { Toast } from 'react-native-toast-message/lib/src/Toast';
 
 import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
+import { useI18n } from '@/hooks/useI18n';
 import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { NetworkType } from '@/models/NetworkModels';
+import { NETWORK_PROPERTIES } from '@/util/configs/network-properties';
 import { getExplorerUrl } from '@/util/symbol/network';
 
 interface Props {
   node: string | null;
   signerPublicKey: string;
+  networkType: NetworkType;
 }
 
 export default function SendTransactionHistory(props: Props): JSX.Element {
   const router = useRouter();
+  const { t } = useI18n();
   const { isLoading, error, next, refresh, transactions } = useTransactionHistory(props.node, 'confirmed', {
     order: 'desc',
     signerPublicKey: props.signerPublicKey,
     embedded: true,
   });
 
+  const epochAdjustment = useMemo(() => {
+    return NETWORK_PROPERTIES[props.networkType || 'mainnet'].epochAdjustment;
+  }, [props.networkType]);
+
   useEffect(() => {
     if (error) {
+      Toast.show({
+        text1: error.message,
+        type: 'error',
+      });
       console.error(error);
     }
   }, [error]);
@@ -33,15 +47,17 @@ export default function SendTransactionHistory(props: Props): JSX.Element {
       onRefresh={refresh}
       refreshing={isLoading}
       renderItem={(e) => (
-        // TODO: 実際には useTransactionHistory が接続中 NODE の NetworkType 等を返却するべきであるため、Network 周りの実装が完了次第、以下も更新する
         <ButtonBase
-          onPress={() => router.push(getExplorerUrl('mainnet', 'transactions', e.meta.hash || e.meta.aggregateHash))}
+          onPress={() =>
+            router.push(getExplorerUrl(props.networkType, 'transactions', e.meta.hash || e.meta.aggregateHash))
+          }
         >
           <ListItem className='flex-col items-start rounded-md border border-input'>
-            <Text className='text-base font-semibold'>{e.transaction.type}</Text>
-            {/* TODO: Network 情報を取得できるようになり次第、以下の実装を進める */}
-            <Text>{new Date(Number(e.meta.timestamp) + 1615853185 * 1000).toLocaleString('ja')}</Text>
-            <Text className='text-xs text-muted-foreground'>{e.meta.hash || e.meta.aggregateHash}</Text>
+            <Text className='text-base font-semibold'>
+              {new Date(Number(e.meta.timestamp) + epochAdjustment * 1000).toLocaleString('ja')}
+            </Text>
+            <Text>{e.meta.hash || e.meta.aggregateHash}</Text>
+            <Text className='text-xs text-muted-foreground'>{e.meta.height} block</Text>
           </ListItem>
         </ButtonBase>
       )}
@@ -50,11 +66,13 @@ export default function SendTransactionHistory(props: Props): JSX.Element {
           <ButtonBase onPress={next} disabled={isLoading ?? error}>
             <View className='w-full flex flex-row gap-2 justify-center items-center py-12'>
               <IconDown isOutline={false} className='text-muted-foreground' />
-              <Text className='text-base text-muted-foreground'>Load More...</Text>
+              <Text className='text-base text-muted-foreground'>{t('common.loadMore')}</Text>
             </View>
           </ButtonBase>
         ) : (
-          <Text className='text-lg text-muted-foreground py-32 text-center'>No transaction history</Text>
+          <Text className='text-lg text-muted-foreground py-32 text-center'>
+            {t('organisms.SendTransactionHistory.noTransactionHistory')}
+          </Text>
         )
       }
     />

--- a/components/organisms/SendTransactionHistory.tsx
+++ b/components/organisms/SendTransactionHistory.tsx
@@ -7,7 +7,7 @@ import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
 import { useI18n } from '@/hooks/useI18n';
-import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
 import { NetworkType } from '@/models/NetworkModels';
 import { NETWORK_PROPERTIES } from '@/util/configs/network-properties';
 import { getExplorerUrl } from '@/util/symbol/network';

--- a/components/organisms/SignWaitTransactionHistory.tsx
+++ b/components/organisms/SignWaitTransactionHistory.tsx
@@ -5,7 +5,7 @@ import { View, Text } from 'react-native';
 import ButtonBase from '@/components/atom/ButtonBase';
 import { IconDown } from '@/components/atom/Icons';
 import { List, ListItem } from '@/components/atom/List';
-import { useTransactionHistory } from '@/hooks/useTransactionSearch';
+import { useTransactionHistory } from '@/hooks/useTransactionHistory';
 import { getExplorerUrl } from '@/util/symbol/network';
 
 interface Props {

--- a/hooks/useGetCurrentBalance.ts
+++ b/hooks/useGetCurrentBalance.ts
@@ -66,7 +66,7 @@ export function useGetCurrentBalance(address: string | null, node: string | null
     return () => {
       unmounted = true;
     };
-  }, [address]);
+  }, [address, node]);
 
   const refresh = async () => {
     if (controller === null) return;

--- a/hooks/useGetCurrentBalance.ts
+++ b/hooks/useGetCurrentBalance.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 
 import { AccountInfoController } from '@/controller/AccountInfoController';
+import { useI18n } from '@/hooks/useI18n';
 import { Mosaic } from '@/models/MosaicModel';
 import { ResponseError } from '@/services/NodeClientService/index';
 
@@ -29,6 +30,7 @@ export function useGetCurrentBalance(address: string | null, node: string | null
   const [balance, setBalance] = useState<number>(0);
   const [mosaics, setMosaics] = useState<Mosaic[]>([]);
   const [error, setError] = useState<Error | null>(null);
+  const { t } = useI18n();
 
   const controller = useMemo(
     // ノードURL は暫定実装
@@ -54,7 +56,7 @@ export function useGetCurrentBalance(address: string | null, node: string | null
         if (err instanceof ResponseError) {
           if (err.response.status === 404) {
             console.warn(`Account not found ${address} in ${node}`);
-            if (!unmounted) setError(new Error(`Account not found ${address} in ${node}`));
+            if (!unmounted) setError(new Error(t('hooks.useGetCurrentBalance.accountNotFound')));
             return;
           }
         }

--- a/hooks/useTransactionHistory.ts
+++ b/hooks/useTransactionHistory.ts
@@ -11,7 +11,7 @@ import {
 
 type Mode = 'confirmed' | 'unconfirmed' | 'partial';
 
-type UseTransactionSearchResult = {
+type UseTransactionHistoryResult = {
   /** データの取得中 */
   isLoading: boolean;
   /** 取得したデータの配列 */
@@ -37,7 +37,7 @@ export function useTransactionHistory(
   node: string | null,
   mode: Mode,
   query: Omit<SearchConfirmedTransactionsRequest, 'pageNumber'>
-): UseTransactionSearchResult {
+): UseTransactionHistoryResult {
   // TransactionInfoDTO は一次元配列では取得の失敗時にどのデータが重複しているか困難で有るため、dict に対して offset ごとに格納する
   const [transactions, setTransactions] = useState<{ [key: string]: TransactionInfoDTO[] }>({});
   const [isLoading, setIsLoading] = useState(false);
@@ -86,8 +86,7 @@ export function useTransactionHistory(
       }
       const body = (await res.raw.json()) as TransactionPage;
 
-      // console.debug(`useTransactionSearch: search result, ${body.data.length}, ${node}, ${JSON.stringify(query)}`);
-      console.debug(`useTransactionSearch: search result,  ${JSON.stringify(body)}`);
+      console.debug(`useTransactionSearch: search result, ${body.data.length}, ${node}, ${JSON.stringify(query)}`);
 
       setTransactions((prev) =>
         pageNumber === 1 ? { [pageNumber.toString()]: body.data } : { ...prev, [pageNumber.toString()]: body.data }

--- a/hooks/useTransactionSearch.ts
+++ b/hooks/useTransactionSearch.ts
@@ -86,7 +86,8 @@ export function useTransactionHistory(
       }
       const body = (await res.raw.json()) as TransactionPage;
 
-      console.debug(`useTransactionSearch: search result, ${body.data.length}, ${node}, ${JSON.stringify(query)}`);
+      // console.debug(`useTransactionSearch: search result, ${body.data.length}, ${node}, ${JSON.stringify(query)}`);
+      console.debug(`useTransactionSearch: search result,  ${JSON.stringify(body)}`);
 
       setTransactions((prev) =>
         pageNumber === 1 ? { [pageNumber.toString()]: body.data } : { ...prev, [pageNumber.toString()]: body.data }

--- a/languages/ja.ts
+++ b/languages/ja.ts
@@ -103,6 +103,11 @@ const ja = {
       noTransactionHistory: 'トランザクション履歴はありません。',
     },
   },
+  hooks: {
+    useGetCurrentBalance: {
+      accountNotFound: 'アカウントが見つからないか、一度も送受信されていません',
+    },
+  },
 };
 
 export default ja;

--- a/languages/ja.ts
+++ b/languages/ja.ts
@@ -15,6 +15,9 @@ const ja = {
     importance: '重要度',
     next: '次へ',
     copied: 'コピーしました',
+    loadMore: '更に読み込む',
+    receive: '受信',
+    send: '送信',
   },
   pages: {
     layout: {
@@ -90,6 +93,14 @@ const ja = {
       enableCamera: 'カメラを有効化',
       cameraDisabled: 'カメラが無効になっています。設定画面よりカメラの使用を許可して下さい。',
       openSettings: '設定を開く',
+    },
+  },
+  organisms: {
+    ReceivedTransactionHistory: {
+      noTransactionHistory: 'トランザクション履歴はありません。',
+    },
+    SendTransactionHistory: {
+      noTransactionHistory: 'トランザクション履歴はありません。',
     },
   },
 };

--- a/languages/ja.ts
+++ b/languages/ja.ts
@@ -77,6 +77,7 @@ const ja = {
       },
       tabsHome: {
         owned_mosaics: '所有モザイク',
+        owned_mosaics_show_more: '更に読み込む',
       },
       index: {},
       transactions: {},

--- a/languages/ja.ts
+++ b/languages/ja.ts
@@ -17,6 +17,12 @@ const ja = {
     copied: 'コピーしました',
   },
   pages: {
+    layout: {
+      wallet: {
+        title: 'ウォレット詳細',
+        header_back_title: '戻る',
+      },
+    },
     login: {
       index: {
         remark: 'アプリを利用する場合、規約に同意頂いたものと致します',
@@ -62,7 +68,12 @@ const ja = {
     },
     wallet: {
       layout: {
+        home_tab_name: 'ホーム',
         transactions_tab_name: '履歴',
+        qr_tab_name: 'QR',
+      },
+      tabsHome: {
+        owned_mosaics: '所有モザイク',
       },
       index: {},
       transactions: {},


### PR DESCRIPTION
homeページとウォレット詳細ページを実装しました。

※ログインページのブランチから派生させちゃったので現状そちらの差分も含まれてます（あっちのPR承認されたらマージします）

- home
  - ウォレット一覧を表示
  - (通知テスト用ボタンをadminに移動)
- ウォレット詳細
    - ホームタブ:  所有モザイクの追加
    - 履歴タブ: 受信/送信履歴の実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced translation support across various components for improved localization.
  - Added push notification management and AsyncStorage data manipulation in the admin interface.
  - Implemented a mnemonic service for better mnemonic generation and storage in login components.
  - Enhanced wallet views with improved balance display and error handling using toasts.

- **Bug Fixes**
  - Corrected method names and improved consistency in the Mnemonic Service.
  - Fixed network type handling in the application state.

- **Refactor**
  - Centralized hooks usage for better state and data management.
  - Reorganized various components to utilize new hooks and services.

- **Internationalization**
  - Updated translations for Japanese language support, including new keys and phrases.

- **UI Enhancements**
  - Added new components for formatted amount display.
  - Updated tab labels to use dynamic translations.

- **Chores**
  - Added necessary imports and modified state handling in various files for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->