### PR TITLE
複数のニーモニックに対応させる

### DIFF
--- a/models/AccountModel.ts
+++ b/models/AccountModel.ts
@@ -18,6 +18,7 @@ export interface PrivateKeyModel {
 
 export interface MnemonicModel {
   mnemonic: string;
+  label?: string;
 }
 
 /** 連絡帳向け */

--- a/services/MnemonicService.ts
+++ b/services/MnemonicService.ts
@@ -32,7 +32,8 @@ export class MnemonicService extends SecureStorage {
   /** ローカルストレージに保存されたニーモニックを返却する */
   public static async getFromStorage(): Promise<MnemonicModel | null> {
     const storage = new SecureStorage(STORAGE_KEYS.secure.MNEMONIC);
-    return JSON.parse((await storage.getSecretItem()) || 'null');
+    // NOTE wallet-baseでは単一のニーモニックのみ対応
+    return JSON.parse((await storage.getSecretItem()) || '[null]')[0];
   }
 
   /** ニーモニックフレーズより MnemonicService インスタンスを返却する */
@@ -68,7 +69,7 @@ export class MnemonicService extends SecureStorage {
 
   /** ニーモニックをストレージへ保存する。デバイスにつきニーモニックは1つとする */
   public async replaceToStorage(): Promise<void> {
-    const item = JSON.stringify({ mnemonic: this.mnemonic } as MnemonicModel);
+    const item = JSON.stringify([{ mnemonic: this.mnemonic, label: 'Default' }] as MnemonicModel[]);
     await this.setSecretItem(item);
   }
 


### PR DESCRIPTION
ニーモニックを複数保存できるようにする
ただし、wallet-baseとしては単一のニーモニックのみ対応とし、実装は各forkでやってもらう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `label` property for mnemonic entries.
- **Enhancements**
  - Improved mnemonic storage handling to support labels and simplified storage format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->